### PR TITLE
feat(ffmpeg): cap logo overlays with 500x140 / 400x140 bounding boxes

### DIFF
--- a/src/infrastructure/services/NodeFFmpegService.ts
+++ b/src/infrastructure/services/NodeFFmpegService.ts
@@ -350,9 +350,9 @@ export class NodeFFmpegService implements FFmpegService {
         // Top-left score overlay
         `[${scoreInputIndex}:v] scale=420:-1:force_original_aspect_ratio=decrease [score];`,
         // Bottom-right DropShot watermark
-        `[${dsInputIndex}:v] scale=500:-1:force_original_aspect_ratio=decrease [ds];`,
+        `[${dsInputIndex}:v] scale=500:140:force_original_aspect_ratio=decrease [ds];`,
         // Top-right client logo
-        `[${clientInputIndex}:v] scale=350:-1:force_original_aspect_ratio=decrease [client];`,
+        `[${clientInputIndex}:v] scale=400:140:force_original_aspect_ratio=decrease [client];`,
         "[base][score] overlay=30:30 [tmp0];",
         "[tmp0][ds] overlay=main_w-overlay_w-10:main_h-overlay_h-10 [tmp1];",
         "[tmp1][client] overlay=main_w-overlay_w-10:10",
@@ -361,9 +361,9 @@ export class NodeFFmpegService implements FFmpegService {
       filterComplex = [
         "[0:v] scale=1920:1080 [base];",
         // Bottom-right DropShot watermark
-        `[${dsInputIndex}:v] scale=500:-1:force_original_aspect_ratio=decrease [ds];`,
+        `[${dsInputIndex}:v] scale=500:140:force_original_aspect_ratio=decrease [ds];`,
         // Top-right client logo
-        `[${clientInputIndex}:v] scale=350:-1:force_original_aspect_ratio=decrease [client];`,
+        `[${clientInputIndex}:v] scale=400:140:force_original_aspect_ratio=decrease [client];`,
         "[base][ds] overlay=main_w-overlay_w-10:main_h-overlay_h-10 [tmp1];",
         "[tmp1][client] overlay=main_w-overlay_w-10:10",
       ].join(" ");


### PR DESCRIPTION
## Summary
- Switch DS watermark from `scale=500:-1` to `scale=500:140` and client logo from `scale=350:-1` to `scale=400:140`.
- Both keep `force_original_aspect_ratio=decrease`, so each logo is now contained inside a fixed bounding box (DS: 500x140, client: 400x140) instead of having an unbounded height.
- Normalizes visual weight across courts/clients regardless of source logo aspect ratio. Square or tall source logos no longer balloon vertically over the stream.

## Scope
- Logo sizing only. No ad-overlay changes, no positioning changes, no new inputs. The ad-overlay work on `feat/ad-overlay` stays out of master.

## Test plan
- [ ] Run a stream against Padel Central with a wide client logo - both logos render within ~140px height.
- [ ] Run a stream against Padel Bridge / a court with a tall/square client logo - logo no longer extends down past ~140px.
- [ ] Confirm DS watermark (bottom-right) and client logo (top-right) positions are unchanged.
- [ ] Confirm scorecard-on and scorecard-off code paths both render correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated video overlay scaling for logos to ensure consistent sizing and proper aspect ratio handling across all video export configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MHA10/drop-shot-streaming-scripts-ubuntu/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->